### PR TITLE
Expose correct `render_mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2022-09-05
+
+### Added
+- Added compliance with the Gym v26 API. This includes multiple breaking changes to the Gym API. See the [Gym Release](https://github.com/openai/gym) for additional information.
+- Reworked the ROM plugin API resulting in reduced startup time when importing `ale_py.roms`.
+- Added a truncation API to the ALE interface to query whether an episode was truncated or terminated (`ale.game_over(with_truncation=true/false)` and `ale.game_truncated()`)
+- Added proper Gym truncation on max episode frames. This no longer relies on the `TimeLimit` wrapper with the new truncation API in Gym v26.
+- Added a setting for truncating on loss-of-life.
+- Added a setting for clamping rewards.
+- Added `const` keywords to attributes in `ale::ALEInterface` (#457) (@AlessioZanga).
+- Added explicit exports via `__all__` in ale-py so linting tools can better detect exports.
+- Added builds for Python 3.11.
+
+### Fixed
+- Fixed a bug that caused needless memory copies with frameskip values greater than 1
+- Moved the Gym environment entrypoint from `gym.envs.atari:AtariEnv` to `ale_py.env.gym:AtariEnv`. This resolves many issues with the namespace package but does break backwards compatability for some Gym code that relied on the entry point being prefixed with `gym.envs.atari`.
+
 ## [0.7.5] - 2022-04-18
 ### Added
 - Added validation for Gym's frameskip values.

--- a/src/python/env/gym.py
+++ b/src/python/env/gym.py
@@ -416,3 +416,7 @@ class AtariEnv(gym.Env, utils.EzPickle):
         Return Gym's observation space.
         """
         return self._obs_space
+
+    @property
+    def render_mode(self) -> str:
+        return self._render_mode


### PR DESCRIPTION
Hi 👋,

To the best of my knowledge, this fork is being used in Gym?

Trying to use Gym, and I realised that for ALE environments the `render_mode` is `None` even though I can call `render` and get an RGB array when I passed into the environment constructor the `render_mode='rgb_array'`.

Gym requires the "correct" `render_mode` [here](https://github.com/openai/gym/blob/6a04d49722724677610e36c1f92908e72f51da0c/gym/wrappers/monitoring/video_recorder.py#L56).

Would it be possible to merge this in?